### PR TITLE
Add `Radio` button component

### DIFF
--- a/mobileapp/src/components/atoms/Radio.tsx
+++ b/mobileapp/src/components/atoms/Radio.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { TouchableHighlight, TouchableOpacity, View } from "react-native";
+import styled from "styled-components/native";
+import Box from "./Box";
+import Spacer from "./Spacer";
+import { Text } from "./Text";
+
+type RadioProps = {
+  options: string[];
+  handlePress: (selectedOption: string) => void;
+};
+
+export default function Radio({ options, handlePress }: RadioProps) {
+  const [radioIndex, setRadioIndex] = useState<number | undefined>(undefined);
+
+  function getRadioIndex(index: number) {
+    setRadioIndex(index);
+  }
+
+  return (
+    <View>
+      {options.map((option, index) => (
+        <TouchableOpacity
+          onPress={() => {
+            handlePress(option);
+            getRadioIndex(index);
+          }}
+          key={option}
+        >
+          <Box flexDirection="row" alignItems="center">
+            <Dot>
+              <DotActive $checked={index === radioIndex} />
+            </Dot>
+            <Spacer axis="horizontal" size={0.5} />
+
+            <Label $checked={index === radioIndex}>{option}</Label>
+          </Box>
+          <Spacer axis="vertical" size={0.5} />
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const Dot = styled.View`
+  width: 24px;
+  height: 24px;
+  border: ${({ theme }) => theme.border.width[1]} solid
+    ${({ theme }) => theme.colors.grey[900]};
+  border-radius: ${({ theme }) => theme.border.radius.circle};
+  align-items: center;
+  justify-content: center;
+`;
+
+const DotActive = styled.View<{ $checked: boolean }>`
+  width: 16px;
+  height: 16px;
+  border-radius: ${({ theme }) => theme.border.radius.circle};
+  background-color: ${({ theme }) => theme.colors.grey[900]};
+  opacity: ${({ $checked }) => ($checked ? "1" : "0")};
+`;
+
+const Label = styled(Text)<{ $checked: boolean }>`
+  color: ${({ $checked, theme }) =>
+    $checked ? theme.colors.grey[900] : theme.colors.grey[500]};
+`;

--- a/mobileapp/src/components/atoms/Radio.tsx
+++ b/mobileapp/src/components/atoms/Radio.tsx
@@ -6,38 +6,32 @@ import Spacer from "./Spacer";
 import { Text } from "./Text";
 
 type RadioProps = {
-  options: string[];
+  option: string;
+  checked: boolean;
   handlePress: (selectedOption: string) => void;
 };
 
-export default function Radio({ options, handlePress }: RadioProps) {
-  const [radioIndex, setRadioIndex] = useState<number | undefined>(undefined);
-
-  function getRadioIndex(index: number) {
-    setRadioIndex(index);
-  }
-
+export default function Radio({
+  option,
+  checked = false,
+  handlePress,
+}: RadioProps) {
   return (
     <View>
-      {options.map((option, index) => (
-        <TouchableOpacity
-          onPress={() => {
-            handlePress(option);
-            getRadioIndex(index);
-          }}
-          key={option}
-        >
-          <Box flexDirection="row" alignItems="center">
-            <Dot>
-              <DotActive $checked={index === radioIndex} />
-            </Dot>
-            <Spacer axis="horizontal" size={0.5} />
+      <TouchableOpacity
+        onPress={() => {
+          handlePress(option);
+        }}
+      >
+        <Box flexDirection="row" alignItems="center">
+          <Dot>
+            <DotActive $checked={checked} />
+          </Dot>
+          <Spacer axis="horizontal" size={0.5} />
 
-            <Label $checked={index === radioIndex}>{option}</Label>
-          </Box>
-          <Spacer axis="vertical" size={0.5} />
-        </TouchableOpacity>
-      ))}
+          <Label $checked={checked}>{option}</Label>
+        </Box>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/mobileapp/src/components/molecules/RadioGroup.tsx
+++ b/mobileapp/src/components/molecules/RadioGroup.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { View } from "react-native";
 import Radio from "../atoms/Radio";
+import Spacer from "../atoms/Spacer";
+import { Text } from "../atoms/Text";
 
 type RadioGroupProps = {
   options: string[];
@@ -10,18 +12,23 @@ type RadioGroupProps = {
 export default function RadioGroup({ options, handlePress }: RadioGroupProps) {
   const [radioIndex, setRadioIndex] = useState<number | undefined>(undefined);
 
+  const lastOption = options[options.length - 1];
+
   return (
     <View>
       {options.map((option, index) => (
-        <Radio
-          key={option}
-          option={option}
-          checked={index === radioIndex}
-          handlePress={() => {
-            handlePress(option);
-            setRadioIndex(index);
-          }}
-        />
+        <View key={option}>
+          <Radio
+            option={option}
+            checked={index === radioIndex}
+            handlePress={() => {
+              handlePress(option);
+              setRadioIndex(index);
+            }}
+          />
+
+          {option !== lastOption && <Spacer axis="vertical" size={0.5} />}
+        </View>
       ))}
     </View>
   );

--- a/mobileapp/src/components/molecules/RadioGroup.tsx
+++ b/mobileapp/src/components/molecules/RadioGroup.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { View } from "react-native";
+import Radio from "../atoms/Radio";
+
+type RadioGroupProps = {
+  options: string[];
+  handlePress: (selectedOption: string) => void;
+};
+
+export default function RadioGroup({ options, handlePress }: RadioGroupProps) {
+  const [radioIndex, setRadioIndex] = useState<number | undefined>(undefined);
+
+  return (
+    <View>
+      {options.map((option, index) => (
+        <Radio
+          key={option}
+          option={option}
+          checked={index === radioIndex}
+          handlePress={() => {
+            handlePress(option);
+            setRadioIndex(index);
+          }}
+        />
+      ))}
+    </View>
+  );
+}


### PR DESCRIPTION
# Description

## Changes and screen (optional)

<!--- Please include a summary of the change or which issue is fixed. -->
- create `Radio` atom component

use case:
```jsx
const [filter, setFilter] = useState<string | null>(null);

<RadioGroup options={["option1", "option2"]} handlePress={(selectedOption) => setFilter(selectedOption)} />
```

Fixed #[issue number]
